### PR TITLE
Add Ubuntu 20.04 as tested OS

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -34,6 +34,7 @@ GraalVM will be found via the GRAALVM_HOME parameter.
 Has been seen working on the following operating systems:
 
 - Fedora 32
+- Ubuntu 20.04
 
 * Building for the JVM
 


### PR DESCRIPTION
Commit message has wrong version name. Note: I tested this using Godot 3.4 which might be useful to mention, although not sure where or if it's needed. Maybe something like `Ubuntu 20.04 (Godot 3.4)`. 